### PR TITLE
Add windows entity for energy representation

### DIFF
--- a/src/Api/Controllers/WindowsController.cs
+++ b/src/Api/Controllers/WindowsController.cs
@@ -1,0 +1,168 @@
+using Api.Dtos;
+using App.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WindowsController(IWindowService windows) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<WindowResponse>>> List(CancellationToken ct)
+    {
+        var items = await windows.ListAsync(ct);
+        return Ok(items.Select(w => new WindowResponse(
+            w.Id,
+            w.Name,
+            w.Description,
+            w.Width,
+            w.Height,
+            w.Area,
+            w.FrameType,
+            w.FrameDetails,
+            w.GlazingType,
+            w.GlazingDetails,
+            w.UValue,
+            w.SolarHeatGainCoefficient,
+            w.VisibleTransmittance,
+            w.AirLeakage,
+            w.EnergyStarRating,
+            w.NFRCRating,
+            w.Orientation,
+            w.Location,
+            w.InstallationType,
+            w.OperationType,
+            w.HasScreens,
+            w.HasStormWindows,
+            w.CreatedAt,
+            w.UpdatedAt
+        )));
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<WindowResponse>> Get(Guid id, CancellationToken ct)
+    {
+        var w = await windows.GetAsync(id, ct);
+        if (w is null) return NotFound();
+        return Ok(new WindowResponse(
+            w.Id,
+            w.Name,
+            w.Description,
+            w.Width,
+            w.Height,
+            w.Area,
+            w.FrameType,
+            w.FrameDetails,
+            w.GlazingType,
+            w.GlazingDetails,
+            w.UValue,
+            w.SolarHeatGainCoefficient,
+            w.VisibleTransmittance,
+            w.AirLeakage,
+            w.EnergyStarRating,
+            w.NFRCRating,
+            w.Orientation,
+            w.Location,
+            w.InstallationType,
+            w.OperationType,
+            w.HasScreens,
+            w.HasStormWindows,
+            w.CreatedAt,
+            w.UpdatedAt
+        ));
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<WindowResponse>> Create([FromBody] CreateWindowRequest request, CancellationToken ct)
+    {
+        var w = await windows.CreateAsync(
+            request.Name,
+            request.Description,
+            request.Width,
+            request.Height,
+            request.Area,
+            request.FrameType,
+            request.FrameDetails,
+            request.GlazingType,
+            request.GlazingDetails,
+            request.UValue,
+            request.SolarHeatGainCoefficient,
+            request.VisibleTransmittance,
+            request.AirLeakage,
+            request.EnergyStarRating,
+            request.NFRCRating,
+            request.Orientation,
+            request.Location,
+            request.InstallationType,
+            request.OperationType,
+            request.HasScreens,
+            request.HasStormWindows,
+            ct
+        );
+        return CreatedAtAction(nameof(Get), new { id = w.Id }, new WindowResponse(
+            w.Id,
+            w.Name,
+            w.Description,
+            w.Width,
+            w.Height,
+            w.Area,
+            w.FrameType,
+            w.FrameDetails,
+            w.GlazingType,
+            w.GlazingDetails,
+            w.UValue,
+            w.SolarHeatGainCoefficient,
+            w.VisibleTransmittance,
+            w.AirLeakage,
+            w.EnergyStarRating,
+            w.NFRCRating,
+            w.Orientation,
+            w.Location,
+            w.InstallationType,
+            w.OperationType,
+            w.HasScreens,
+            w.HasStormWindows,
+            w.CreatedAt,
+            w.UpdatedAt
+        ));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateWindowRequest request, CancellationToken ct)
+    {
+        await windows.UpdateAsync(
+            id,
+            request.Name,
+            request.Description,
+            request.Width,
+            request.Height,
+            request.Area,
+            request.FrameType,
+            request.FrameDetails,
+            request.GlazingType,
+            request.GlazingDetails,
+            request.UValue,
+            request.SolarHeatGainCoefficient,
+            request.VisibleTransmittance,
+            request.AirLeakage,
+            request.EnergyStarRating,
+            request.NFRCRating,
+            request.Orientation,
+            request.Location,
+            request.InstallationType,
+            request.OperationType,
+            request.HasScreens,
+            request.HasStormWindows,
+            ct
+        );
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        await windows.DeleteAsync(id, ct);
+        return NoContent();
+    }
+}

--- a/src/Api/Dtos/WindowDtos.cs
+++ b/src/Api/Dtos/WindowDtos.cs
@@ -1,0 +1,78 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.Dtos;
+
+public record CreateWindowRequest(
+    [param: Required] string Name,
+    [param: MaxLength(1000)] string? Description,
+    [param: Range(0.1, 100)] double Width,
+    [param: Range(0.1, 100)] double Height,
+    [param: Range(0.01, 1000)] double Area,
+    [param: Required] string FrameType,
+    [param: MaxLength(500)] string? FrameDetails,
+    [param: Required] string GlazingType,
+    [param: MaxLength(500)] string? GlazingDetails,
+    [param: Range(0, 10)] double? UValue,
+    [param: Range(0, 1)] double? SolarHeatGainCoefficient,
+    [param: Range(0, 1)] double? VisibleTransmittance,
+    [param: Range(0, 100)] double? AirLeakage,
+    [param: MaxLength(50)] string? EnergyStarRating,
+    [param: MaxLength(50)] string? NFRCRating,
+    [param: MaxLength(50)] string? Orientation,
+    [param: MaxLength(100)] string? Location,
+    [param: MaxLength(50)] string? InstallationType,
+    [param: MaxLength(100)] string? OperationType,
+    bool? HasScreens,
+    bool? HasStormWindows
+);
+
+public record UpdateWindowRequest(
+    [param: Required] string Name,
+    [param: MaxLength(1000)] string? Description,
+    [param: Range(0.1, 100)] double Width,
+    [param: Range(0.1, 100)] double Height,
+    [param: Range(0.01, 1000)] double Area,
+    [param: Required] string FrameType,
+    [param: MaxLength(500)] string? FrameDetails,
+    [param: Required] string GlazingType,
+    [param: MaxLength(500)] string? GlazingDetails,
+    [param: Range(0, 10)] double? UValue,
+    [param: Range(0, 1)] double? SolarHeatGainCoefficient,
+    [param: Range(0, 1)] double? VisibleTransmittance,
+    [param: Range(0, 100)] double? AirLeakage,
+    [param: MaxLength(50)] string? EnergyStarRating,
+    [param: MaxLength(50)] string? NFRCRating,
+    [param: MaxLength(50)] string? Orientation,
+    [param: MaxLength(100)] string? Location,
+    [param: MaxLength(50)] string? InstallationType,
+    [param: MaxLength(100)] string? OperationType,
+    bool? HasScreens,
+    bool? HasStormWindows
+);
+
+public record WindowResponse(
+    Guid Id,
+    string Name,
+    string? Description,
+    double Width,
+    double Height,
+    double Area,
+    string FrameType,
+    string? FrameDetails,
+    string GlazingType,
+    string? GlazingDetails,
+    double? UValue,
+    double? SolarHeatGainCoefficient,
+    double? VisibleTransmittance,
+    double? AirLeakage,
+    string? EnergyStarRating,
+    string? NFRCRating,
+    string? Orientation,
+    string? Location,
+    string? InstallationType,
+    string? OperationType,
+    bool? HasScreens,
+    bool? HasStormWindows,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt
+);

--- a/src/Api/Windows.http
+++ b/src/Api/Windows.http
@@ -1,0 +1,96 @@
+@baseUrl = https://localhost:7001
+@windowId = {{createWindow.response.body.id}}
+
+### Get all windows
+GET {{baseUrl}}/api/windows
+Accept: application/json
+
+### Create a new window
+# @name createWindow
+POST {{baseUrl}}/api/windows
+Content-Type: application/json
+
+{
+  "name": "Living Room South Window",
+  "description": "Large south-facing window in living room for natural light and solar gain",
+  "width": 6.0,
+  "height": 4.0,
+  "area": 24.0,
+  "frameType": "Vinyl",
+  "frameDetails": "White vinyl frame with reinforced corners",
+  "glazingType": "Double",
+  "glazingDetails": "Low-E coating, argon fill",
+  "uValue": 0.28,
+  "solarHeatGainCoefficient": 0.32,
+  "visibleTransmittance": 0.68,
+  "airLeakage": 0.1,
+  "energyStarRating": "Energy Star Certified",
+  "nfrcRating": "NFRC-100-2020",
+  "orientation": "South",
+  "location": "Living Room",
+  "installationType": "New Construction",
+  "operationType": "Double-hung",
+  "hasScreens": true,
+  "hasStormWindows": false
+}
+
+### Get window by ID
+GET {{baseUrl}}/api/windows/{{windowId}}
+Accept: application/json
+
+### Update window
+PUT {{baseUrl}}/api/windows/{{windowId}}
+Content-Type: application/json
+
+{
+  "name": "Living Room South Window - Updated",
+  "description": "Large south-facing window in living room for natural light and solar gain - Updated with better specs",
+  "width": 6.0,
+  "height": 4.0,
+  "area": 24.0,
+  "frameType": "Fiberglass",
+  "frameDetails": "White fiberglass frame with reinforced corners and improved insulation",
+  "glazingType": "Triple",
+  "glazingDetails": "Low-E coating, krypton fill, improved spacers",
+  "uValue": 0.20,
+  "solarHeatGainCoefficient": 0.28,
+  "visibleTransmittance": 0.65,
+  "airLeakage": 0.05,
+  "energyStarRating": "Energy Star Most Efficient",
+  "nfrcRating": "NFRC-100-2020",
+  "orientation": "South",
+  "location": "Living Room",
+  "installationType": "Replacement",
+  "operationType": "Casement",
+  "hasScreens": true,
+  "hasStormWindows": false
+}
+
+### Delete window
+DELETE {{baseUrl}}/api/windows/{{windowId}}
+
+### Create another window example - Kitchen Window
+POST {{baseUrl}}/api/windows
+Content-Type: application/json
+
+{
+  "name": "Kitchen East Window",
+  "description": "Small east-facing window above kitchen sink",
+  "width": 3.0,
+  "height": 2.5,
+  "area": 7.5,
+  "frameType": "Wood",
+  "frameDetails": "Pine frame with natural finish",
+  "glazingType": "Double",
+  "glazingDetails": "Clear glass, no special coatings",
+  "uValue": 0.35,
+  "solarHeatGainCoefficient": 0.65,
+  "visibleTransmittance": 0.85,
+  "airLeakage": 0.2,
+  "orientation": "East",
+  "location": "Kitchen",
+  "installationType": "Existing",
+  "operationType": "Fixed",
+  "hasScreens": false,
+  "hasStormWindows": true
+}

--- a/src/App/Abstractions/IWindowRepository.cs
+++ b/src/App/Abstractions/IWindowRepository.cs
@@ -1,0 +1,12 @@
+using Domain.Entities;
+
+namespace App.Abstractions;
+
+public interface IWindowRepository
+{
+    Task<Window?> GetAsync(Guid id, CancellationToken ct = default);
+    Task<IReadOnlyList<Window>> ListAsync(CancellationToken ct = default);
+    Task<Window> AddAsync(Window window, CancellationToken ct = default);
+    Task UpdateAsync(Window window, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/App/Abstractions/IWindowService.cs
+++ b/src/App/Abstractions/IWindowService.cs
@@ -1,0 +1,12 @@
+using Domain.Entities;
+
+namespace App.Abstractions;
+
+public interface IWindowService
+{
+    Task<Window?> GetAsync(Guid id, CancellationToken ct = default);
+    Task<IReadOnlyList<Window>> ListAsync(CancellationToken ct = default);
+    Task<Window> CreateAsync(string name, string? description, double width, double height, double area, string frameType, string? frameDetails, string glazingType, string? glazingDetails, double? uValue = null, double? solarHeatGainCoefficient = null, double? visibleTransmittance = null, double? airLeakage = null, string? energyStarRating = null, string? nfrcRating = null, string? orientation = null, string? location = null, string? installationType = null, string? operationType = null, bool? hasScreens = null, bool? hasStormWindows = null, CancellationToken ct = default);
+    Task UpdateAsync(Guid id, string name, string? description, double width, double height, double area, string frameType, string? frameDetails, string glazingType, string? glazingDetails, double? uValue = null, double? solarHeatGainCoefficient = null, double? visibleTransmittance = null, double? airLeakage = null, string? energyStarRating = null, string? nfrcRating = null, string? orientation = null, string? location = null, string? installationType = null, string? operationType = null, bool? hasScreens = null, bool? hasStormWindows = null, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/App/DependencyInjection.cs
+++ b/src/App/DependencyInjection.cs
@@ -11,6 +11,7 @@ public static class DependencyInjection
         services.AddScoped<IPersonService, PersonService>();
         services.AddScoped<IRoleService, RoleService>();
         services.AddScoped<IWallService, WallService>();
+        services.AddScoped<IWindowService, WindowService>();
         return services;
     }
 }

--- a/src/App/Services/WindowService.cs
+++ b/src/App/Services/WindowService.cs
@@ -1,0 +1,75 @@
+using App.Abstractions;
+using Domain.Entities;
+
+namespace App.Services;
+
+public class WindowService(IWindowRepository windows) : IWindowService
+{
+    public async Task<Window?> GetAsync(Guid id, CancellationToken ct = default)
+        => await windows.GetAsync(id, ct);
+
+    public async Task<IReadOnlyList<Window>> ListAsync(CancellationToken ct = default)
+        => await windows.ListAsync(ct);
+
+    public async Task<Window> CreateAsync(string name, string? description, double width, double height, double area, string frameType, string? frameDetails, string glazingType, string? glazingDetails, double? uValue = null, double? solarHeatGainCoefficient = null, double? visibleTransmittance = null, double? airLeakage = null, string? energyStarRating = null, string? nfrcRating = null, string? orientation = null, string? location = null, string? installationType = null, string? operationType = null, bool? hasScreens = null, bool? hasStormWindows = null, CancellationToken ct = default)
+    {
+        var window = new Window
+        {
+            Name = name,
+            Description = description,
+            Width = width,
+            Height = height,
+            Area = area,
+            FrameType = frameType,
+            FrameDetails = frameDetails,
+            GlazingType = glazingType,
+            GlazingDetails = glazingDetails,
+            UValue = uValue,
+            SolarHeatGainCoefficient = solarHeatGainCoefficient,
+            VisibleTransmittance = visibleTransmittance,
+            AirLeakage = airLeakage,
+            EnergyStarRating = energyStarRating,
+            NFRCRating = nfrcRating,
+            Orientation = orientation,
+            Location = location,
+            InstallationType = installationType,
+            OperationType = operationType,
+            HasScreens = hasScreens,
+            HasStormWindows = hasStormWindows
+        };
+        return await windows.AddAsync(window, ct);
+    }
+
+    public async Task UpdateAsync(Guid id, string name, string? description, double width, double height, double area, string frameType, string? frameDetails, string glazingType, string? glazingDetails, double? uValue = null, double? solarHeatGainCoefficient = null, double? visibleTransmittance = null, double? airLeakage = null, string? energyStarRating = null, string? nfrcRating = null, string? orientation = null, string? location = null, string? installationType = null, string? operationType = null, bool? hasScreens = null, bool? hasStormWindows = null, CancellationToken ct = default)
+    {
+        var window = await windows.GetAsync(id, ct) ?? throw new KeyNotFoundException($"Window {id} not found");
+        
+        window.Name = name;
+        window.Description = description;
+        window.Width = width;
+        window.Height = height;
+        window.Area = area;
+        window.FrameType = frameType;
+        window.FrameDetails = frameDetails;
+        window.GlazingType = glazingType;
+        window.GlazingDetails = glazingDetails;
+        window.UValue = uValue;
+        window.SolarHeatGainCoefficient = solarHeatGainCoefficient;
+        window.VisibleTransmittance = visibleTransmittance;
+        window.AirLeakage = airLeakage;
+        window.EnergyStarRating = energyStarRating;
+        window.NFRCRating = nfrcRating;
+        window.Orientation = orientation;
+        window.Location = location;
+        window.InstallationType = installationType;
+        window.OperationType = operationType;
+        window.HasScreens = hasScreens;
+        window.HasStormWindows = hasStormWindows;
+        window.UpdatedAt = DateTime.UtcNow;
+
+        await windows.UpdateAsync(window, ct);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+        => await windows.DeleteAsync(id, ct);
+}

--- a/src/Domain/Entities/Window.cs
+++ b/src/Domain/Entities/Window.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Domain.Entities
+{
+    public class Window
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        [Required]
+        [MaxLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [MaxLength(1000)]
+        public string? Description { get; set; }
+
+        // Geometry properties
+        public double Width { get; set; } // in feet
+        public double Height { get; set; } // in feet
+        public double Area { get; set; } // in square feet (calculated or specified)
+
+        // Frame properties
+        [Required]
+        [MaxLength(100)]
+        public string FrameType { get; set; } = string.Empty; // e.g., "Vinyl", "Wood", "Aluminum", "Fiberglass"
+
+        [MaxLength(500)]
+        public string? FrameDetails { get; set; } // Additional frame specifications
+
+        // Glazing properties
+        [Required]
+        [MaxLength(100)]
+        public string GlazingType { get; set; } = string.Empty; // e.g., "Double", "Triple", "Single"
+
+        [MaxLength(500)]
+        public string? GlazingDetails { get; set; } // e.g., "Low-E coating", "Argon fill"
+
+        // Energy modeling properties
+        public double? UValue { get; set; } // Thermal transmittance (BTU/hr·ft²·°F)
+        public double? SolarHeatGainCoefficient { get; set; } // SHGC (0-1)
+        public double? VisibleTransmittance { get; set; } // VT (0-1)
+        public double? AirLeakage { get; set; } // cfm/ft² at 75 Pa
+
+        // Performance ratings
+        [MaxLength(50)]
+        public string? EnergyStarRating { get; set; } // Energy Star qualification
+        [MaxLength(50)]
+        public string? NFRCRating { get; set; } // NFRC certification number
+
+        // Orientation and location
+        [MaxLength(50)]
+        public string? Orientation { get; set; } // North, South, East, West, etc.
+        [MaxLength(100)]
+        public string? Location { get; set; } // Room or building location
+        [MaxLength(50)]
+        public string? InstallationType { get; set; } // New construction, Replacement, etc.
+
+        // Operational properties
+        [MaxLength(100)]
+        public string? OperationType { get; set; } // Fixed, Casement, Double-hung, Sliding, etc.
+        public bool? HasScreens { get; set; }
+        public bool? HasStormWindows { get; set; }
+
+        // Metadata
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime? UpdatedAt { get; set; }
+    }
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -11,6 +11,7 @@ public static class DependencyInjection
         services.AddSingleton<IPersonRepository, InMemoryPersonRepository>();
         services.AddSingleton<IRoleRepository, InMemoryRoleRepository>();
         services.AddSingleton<IWallRepository, InMemoryWallRepository>();
+        services.AddSingleton<IWindowRepository, InMemoryWindowRepository>();
         return services;
     }
 }

--- a/src/Infrastructure/Repositories/InMemory/InMemoryWindowRepository.cs
+++ b/src/Infrastructure/Repositories/InMemory/InMemoryWindowRepository.cs
@@ -1,0 +1,33 @@
+using App.Abstractions;
+using Domain.Entities;
+
+namespace Infrastructure.Repositories.InMemory;
+
+public class InMemoryWindowRepository : IWindowRepository
+{
+    private readonly Dictionary<Guid, Window> _store = new();
+
+    public Task<Window?> GetAsync(Guid id, CancellationToken ct = default)
+        => Task.FromResult(_store.TryGetValue(id, out var w) ? w : null);
+
+    public Task<IReadOnlyList<Window>> ListAsync(CancellationToken ct = default)
+        => Task.FromResult((IReadOnlyList<Window>)_store.Values.ToList());
+
+    public Task<Window> AddAsync(Window window, CancellationToken ct = default)
+    {
+        _store[window.Id] = window;
+        return Task.FromResult(window);
+    }
+
+    public Task UpdateAsync(Window window, CancellationToken ct = default)
+    {
+        _store[window.Id] = window;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        _store.Remove(id);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Add a new `Window` entity to the backend for energy representation, including dimensions and energy characteristics.

---
<a href="https://cursor.com/background-agent?bcId=bc-831dd441-3da0-4dde-aa9a-caa375614549">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-831dd441-3da0-4dde-aa9a-caa375614549">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

