### PR TITLE
fix: workflow formatting verification for staging deployment

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -114,9 +114,24 @@ jobs:
           # Push changes
           git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}
           echo "✅ Formatting changes pushed successfully"
+          
+          # IMPORTANT: Pull the changes back to update our local working copy
+          echo "📥 Pulling formatting changes back to working copy..."
+          git pull origin ${{ github.event.pull_request.head.ref || github.ref_name }}
         else
           echo "✅ No formatting changes needed - code is already properly formatted"
         fi
+        
+    - name: Verify Final Formatting
+      run: |
+        echo "🔍 Verifying that all code is now properly formatted..."
+        dotnet format Crud.sln --verify-no-changes --verbosity diagnostic
+        if [ $? -ne 0 ]; then
+          echo "❌ ERROR: Code still has formatting issues after auto-format!"
+          echo "This should not happen. Please check the workflow configuration."
+          exit 1
+        fi
+        echo "✅ All code is properly formatted and ready for merge!"
         
     - name: Check for common code issues
       run: |


### PR DESCRIPTION
## Summary
- Adds verification step to PR validation workflow to ensure formatting changes flow through to staging
- Prevents staging deployment failures due to formatting issues

## Changes
- Added `Verify Final Formatting` step after auto-format in PR validation
- Pulls formatting changes back to working copy after commit
- Ensures all code is properly formatted before merge

## Context
This fixes the issue where staging deployment was failing due to formatting issues even though PR validation was passing. The PR validation was auto-formatting but not verifying the final state.

## Test Plan
- [x] PR validation workflow runs successfully
- [ ] Staging deployment should pass formatting checks after merge

🤖 Generated with [Claude Code](https://claude.ai/code)