### PR TITLE
Fix E2E test configuration for staging deployment

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,7 @@
       "Bash($env:ASPNETCORE_ENVIRONMENT=\"Development\")",
       "Bash($env:ASPNETCORE_URLS=\"http://localhost:5172\")",
       "Bash($env:DatabaseProvider=\"SQLite\")",
-      "Bash(API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 npx playwright test tests/setup/ci-configuration.test.ts:51 --config=playwright.config.webserver.ts)",
+      "Bash(API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 npx playwright test tests/setup/ci-configuration.test.ts:51)",
       "Bash(chmod:*)",
       "Bash(CI=true npx playwright test serial-example.spec.ts --project=chromium --grep \"should create a new person\" --reporter=list)",
       "Bash(cross-env:*)",
@@ -94,9 +94,10 @@
       "Bash(git rm:*)",
       "Bash(dotnet format:*)",
       "Bash(cat:*)",
-      "Bash(CI=true npx playwright test api-health.spec.ts --config=playwright.config.webserver.ts --reporter=list --timeout=30000)",
+      "Bash(CI=true npx playwright test api-health.spec.ts --reporter=list --timeout=30000)",
       "Bash(git commit:*)",
-      "Bash(ng build:*)"
+      "Bash(ng build:*)",
+      "Read(//c/Users/chadm/source/repos/Crud/**)"
     ],
     "deny": [],
     "ask": [],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,9 @@ cd src/Angular && npm run lint
 
 ⚠️ **CRITICAL: DO NOT CHANGE THE TEST COMMANDS** ⚠️
 
-The `test:smoke`, `test:critical`, and `test:extended` commands in `test/Tests.E2E.NG/package.json` MUST use `playwright.config.webserver.ts`. 
+The `test:smoke`, `test:critical`, and `test:extended` commands in `test/Tests.E2E.NG/package.json` require specific environment variables for CI compatibility. 
 
-**DO NOT "simplify" them to use the default playwright.config.ts** - this will break CI!
+**DO NOT "simplify" them by removing the environment variables** - this will break CI!
 
 ### Why This Matters
 - The complex-looking commands with environment variables are REQUIRED
@@ -101,9 +101,9 @@ npm run test:extended    # Extended test suite
 "test:critical": "playwright test --grep @critical"  # ❌ BROKEN IN CI
 ```
 
-**UPDATE**: E2E tests use Playwright's built-in webServer configuration. See `docs/Decisions/0003-E2E-Testing-Database-Use-Playwrights-webServer.md` for details.
+**UPDATE**: E2E tests use Playwright's built-in webServer configuration (now in the default `playwright.config.ts`). See `docs/Decisions/0003-E2E-Testing-Database-Use-Playwrights-webServer.md` for details.
 
-- **Playwright webServer**: Automatic server management, unique database per test run (recommended approach)
+- **Playwright webServer**: Automatic server management, unique database per test run (built into `playwright.config.ts`)
 - Tests are tagged: `@smoke` (2 min), `@critical` (5 min), `@extended` (10 min)
 - Database isolation via unique filenames prevents locking issues
 - Serial execution strategy (`workers: 1`) for SQLite/EF Core compatibility

--- a/test/Tests.E2E.NG/CI-TEST-WARNING.md
+++ b/test/Tests.E2E.NG/CI-TEST-WARNING.md
@@ -2,15 +2,14 @@
 
 ## DO NOT CHANGE THE TEST COMMANDS
 
-The `test:smoke`, `test:critical`, and `test:extended` scripts in package.json
-are configured specifically for CI compatibility. They MUST use 
-`playwright.config.webserver.ts`.
+The `test:smoke`, `test:critical`, `test:extended`, and `test:webserver` scripts in package.json
+are configured specifically for CI compatibility. They MUST include all environment variables.
 
 ## History of This Issue
 - Fixed multiple times, broken multiple times
 - Each "simplification" breaks CI
 - The complex commands are NOT a mistake
-- See GitHub issue #79 for permanent solution
+- Environment variables are REQUIRED for proper server configuration
 
 ## The Rule
 **NEVER** change these commands to the "simpler" form:
@@ -19,20 +18,31 @@ are configured specifically for CI compatibility. They MUST use
 "test:smoke": "playwright test --grep @smoke"
 
 // ✅ CORRECT - WORKS IN CI  
-"test:smoke": "npx cross-env TEST_CATEGORY=smoke ... playwright test --config=playwright.config.webserver.ts"
+"test:smoke": "npx cross-env TEST_CATEGORY=smoke API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 playwright test"
 ```
 
 ## Why It Keeps Breaking
 Developers (and AI assistants) see the long command and think it can be
-simplified. IT CANNOT. The complexity is there for a reason.
+simplified. IT CANNOT. The environment variables are essential for:
+- Proper port configuration
+- Database path isolation
+- API/Angular URL configuration
+- CI/CD compatibility
 
-## Files That Should NOT Be Used for CI Tests
-- `playwright.config.ts` - Has global-setup issues
-- `tests/setup/global-setup.ts` - Manual server management fails in CI
-- `playwright.config.serial.ts` - Also uses global-setup
+## Current Configuration
+As of September 2025, all tests use the default `playwright.config.ts` which includes:
+- Built-in webServer configuration for automatic server management
+- Unique database files per test run to prevent locking
+- Serial execution (workers: 1) for SQLite compatibility
+- Proper CI/CD environment detection
 
-## The Correct File
-- `playwright.config.webserver.ts` - Uses Playwright's built-in server management
+## The Test Commands
+All test commands follow the same pattern with environment variables:
+- `test`: Basic playwright test
+- `test:webserver`: Full test suite with all environment variables
+- `test:smoke`: Quick 2-minute smoke tests (@smoke tag)
+- `test:critical`: 5-minute critical path tests (@critical tag)
+- `test:extended`: 10-minute extended test suite (@extended tag)
 
 If you're reading this because tests are failing in CI, check if someone
-"simplified" the test commands in package.json.
+"simplified" the test commands in package.json by removing environment variables.

--- a/test/Tests.E2E.NG/README.md
+++ b/test/Tests.E2E.NG/README.md
@@ -115,10 +115,10 @@ Check the uploaded artifacts:
 ## Migration from Legacy Setup
 
 If you have custom test configurations:
-1. Switch to `playwright.config.webserver.ts`
-2. Remove dependency on global setup files
-3. Use unique database names with timestamps
-4. Let Playwright manage server lifecycle
+1. Use the default `playwright.config.ts` (includes webServer configuration)
+2. Ensure all test commands include required environment variables
+3. Database isolation is handled automatically with unique filenames
+4. Playwright manages server lifecycle via built-in webServer feature
 
 ## Contributing
 

--- a/test/Tests.E2E.NG/package.json
+++ b/test/Tests.E2E.NG/package.json
@@ -4,6 +4,7 @@
   "description": "End-to-end tests for Angular application and API",
   "scripts": {
     "test": "playwright test",
+    "test:webserver": "npx cross-env API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 playwright test",
     "test:smoke": "npx cross-env TEST_CATEGORY=smoke API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 playwright test",
     "test:critical": "npx cross-env TEST_CATEGORY=critical API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 playwright test",
     "test:extended": "npx cross-env TEST_CATEGORY=extended API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 playwright test",


### PR DESCRIPTION
- Added missing test:webserver script to package.json with proper environment variables
- Updated documentation to reflect current test configuration (playwright.config.ts with built-in webServer)
- Removed references to non-existent playwright.config.webserver.ts
- Clarified that environment variables are required for CI compatibility, not specific config files
- Updated CI-TEST-WARNING.md with accurate current state
- Fixed .claude/settings.local.json approved commands

This fixes the staging deployment failure where npm run test:webserver was missing.

🤖 Generated with [Claude Code](https://claude.ai/code)