### PR TITLE
fix: re-enable backend integration tests with artifact-independent ap…

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -315,8 +315,8 @@ jobs:
   backend-integration-tests:
     name: Backend Integration Tests
     runs-on: ubuntu-latest
-    needs: [build, code-quality]
-    if: false  # Temporarily disabled pending CI artifact resolution
+    needs: [code-quality]  # Remove build dependency to avoid artifact issues
+    if: always() && needs.code-quality.result == 'success'
     
     steps:
     - name: Checkout code
@@ -329,45 +329,18 @@ jobs:
         cache: true
         cache-dependency-path: 'src/**/*.csproj'
         
-    - name: Download build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: feature-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Download PR build artifacts (fallback)
-      uses: actions/download-artifact@v4
-      with:
-        name: pr-build-${{ github.sha }}
-      continue-on-error: true
-    
-    - name: Copy appsettings to test output
-      run: |
-        echo "📁 Listing artifact structure:"
-        ls -la src/Api/ || echo "src/Api/ not found"
-        ls -la src/Api/bin/Release/net8.0/ || echo "bin directory not found"
-        
-        # Copy appsettings files if they exist
-        if [ -f "src/Api/appsettings.json" ]; then
-          cp src/Api/appsettings*.json src/Api/bin/Release/net8.0/
-          echo "✅ Appsettings files copied from src/Api/"
-        elif [ -f "appsettings.json" ]; then
-          cp appsettings*.json src/Api/bin/Release/net8.0/
-          echo "✅ Appsettings files copied from root"
-        else
-          echo "⚠️ No appsettings files found to copy"
-        fi
-        
-        echo "📁 Final output directory contents:"
-        ls -la src/Api/bin/Release/net8.0/*.json || echo "No JSON files in output"
+    - name: Restore dependencies
+      run: dotnet restore solutions/Crud.sln
+      
+    - name: Build solution for tests
+      run: dotnet build solutions/Crud.sln --no-restore --configuration Release
         
     - name: Run Backend Integration Tests with SQLite
-      run: dotnet test test/Tests.Integration.Backend/Tests.Integration.Backend.csproj --configuration Release --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=detailed"
-      continue-on-error: true
+      run: dotnet test test/Tests.Integration.Backend/Tests.Integration.Backend.csproj --no-build --configuration Release --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=detailed"
       env:
         CI: true
         ASPNETCORE_ENVIRONMENT: Testing
-      timeout-minutes: 10
+      timeout-minutes: 15
       
     - name: Upload integration test results
       uses: actions/upload-artifact@v4
@@ -484,7 +457,7 @@ jobs:
   pr-validation-summary:
     name: PR Validation Summary
     runs-on: ubuntu-latest
-    needs: [build, backend-unit-tests, frontend-unit-tests, e2e-smoke-tests]
+    needs: [build, backend-unit-tests, frontend-unit-tests, backend-integration-tests, e2e-smoke-tests]
     if: always()
     
     steps:
@@ -521,7 +494,7 @@ jobs:
         echo "| Build | $BUILD_STATUS |" >> $GITHUB_STEP_SUMMARY
         echo "| Backend Unit Tests | ${{ needs.backend-unit-tests.result == 'success' && '✅ Passed' || (needs.backend-unit-tests.result == 'failure' && '❌ Failed') || (needs.backend-unit-tests.result == 'cancelled' && '⏹️ Cancelled') || '⏸️ Skipped' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Frontend Unit Tests | ${{ needs.frontend-unit-tests.result == 'success' && '✅ Passed' || (needs.frontend-unit-tests.result == 'failure' && '❌ Failed') || (needs.frontend-unit-tests.result == 'cancelled' && '⏹️ Cancelled') || '⏸️ Skipped' }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Backend Integration Tests | ⚠️ Temporarily Disabled |" >> $GITHUB_STEP_SUMMARY
+        echo "| Backend Integration Tests | ${{ needs.backend-integration-tests.result == 'success' && '✅ Passed' || (needs.backend-integration-tests.result == 'failure' && '❌ Failed') || (needs.backend-integration-tests.result == 'cancelled' && '⏹️ Cancelled') || '⏸️ Skipped' }} |" >> $GITHUB_STEP_SUMMARY
         
         # E2E tests status - different handling for dev vs main PRs
         if [ "${{ github.event.pull_request.base.ref }}" == "dev" ]; then
@@ -533,29 +506,31 @@ jobs:
         
         # Check overall status - different logic for dev vs main PRs
         if [ "${{ github.event.pull_request.base.ref }}" == "dev" ]; then
-          # For dev PRs, don't require E2E tests or backend integration tests (temporary skip)
+          # For dev PRs, don't require E2E tests but include backend integration tests
           if [ "${{ needs.build.result }}" == "success" ] && \
              [ "${{ needs.backend-unit-tests.result }}" == "success" ] && \
-             [ "${{ needs.frontend-unit-tests.result }}" == "success" ]; then
+             [ "${{ needs.frontend-unit-tests.result }}" == "success" ] && \
+             [ "${{ needs.backend-integration-tests.result }}" == "success" ]; then
             echo "### ✅ All validation checks passed for dev branch!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Progressive Testing:** E2E tests will run automatically during staging deployment" >> $GITHUB_STEP_SUMMARY
-            echo "**Note:** Backend integration tests are temporarily skipped pending CI artifact resolution" >> $GITHUB_STEP_SUMMARY
+            echo "**Integration Coverage:** Backend integration tests included for comprehensive validation" >> $GITHUB_STEP_SUMMARY
           else
             echo "### ❌ Some validation checks failed" >> $GITHUB_STEP_SUMMARY
             echo "Please review the test results above for details." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
         else
-          # For main PRs, require E2E tests (backend integration tests temporarily skipped)
+          # For main PRs, require E2E tests and backend integration tests
           if [ "${{ needs.build.result }}" == "success" ] && \
              [ "${{ needs.backend-unit-tests.result }}" == "success" ] && \
              [ "${{ needs.frontend-unit-tests.result }}" == "success" ] && \
+             [ "${{ needs.backend-integration-tests.result }}" == "success" ] && \
              [ "${{ needs.e2e-smoke-tests.result }}" == "success" ]; then
             echo "### ✅ All validation checks passed for main branch!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**E2E Tests:** Smoke tests completed (~22 tests) for production readiness" >> $GITHUB_STEP_SUMMARY
-            echo "**Note:** Backend integration tests are temporarily skipped pending CI artifact resolution" >> $GITHUB_STEP_SUMMARY
+            echo "**Integration Coverage:** Complete test suite including backend integration tests" >> $GITHUB_STEP_SUMMARY
           else
             echo "### ❌ Some validation checks failed" >> $GITHUB_STEP_SUMMARY
             echo "Please review the test results above for details." >> $GITHUB_STEP_SUMMARY

--- a/docs/03-Development/guidelines/command-handler-checklist.md
+++ b/docs/03-Development/guidelines/command-handler-checklist.md
@@ -1,0 +1,87 @@
+# Command Handler Development Checklist
+
+This checklist ensures consistency and prevents common issues in command handler implementations.
+
+## Update Command Handler Requirements
+
+When implementing an `Update*CommandHandler`, ensure you follow these requirements:
+
+### ✅ **Critical: UpdatedAt Assignment**
+
+**ALWAYS** set `UpdatedAt = DateTime.UtcNow` in update command handlers:
+
+```csharp
+public class UpdateEntityCommandHandler : IRequestHandler<UpdateEntityCommand>
+{
+    public async Task Handle(UpdateEntityCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await repository.GetAsync(request.Id, cancellationToken);
+        
+        // ... update entity properties ...
+        
+        entity.UpdatedAt = DateTime.UtcNow;  // ← REQUIRED!
+        await repository.UpdateAsync(entity, cancellationToken);
+    }
+}
+```
+
+### Why This Matters
+
+- **Conditional Requests**: HTTP Last-Modified headers depend on UpdatedAt
+- **Caching**: Output caching uses UpdatedAt for cache invalidation  
+- **API Consistency**: All entities must have consistent timestamp behavior
+- **Client Synchronization**: Clients rely on UpdatedAt for optimistic concurrency
+
+### Current Implementation Status
+
+All entities currently implement this correctly:
+
+✅ **Windows**: `window.UpdatedAt = DateTime.UtcNow`  
+✅ **Walls**: `wall.UpdatedAt = DateTime.UtcNow`  
+✅ **Roles**: `role.UpdatedAt = DateTime.UtcNow`  
+✅ **People**: `person.UpdatedAt = DateTime.UtcNow`  
+
+## Other Command Handler Best Practices
+
+### Error Handling
+- Throw `KeyNotFoundException` when entity not found
+- Use appropriate domain exceptions for business rule violations
+
+### Repository Pattern
+- Always use the injected repository interface
+- Follow async/await patterns consistently
+
+### Transaction Scope
+- Update operations should be atomic
+- Consider cascade updates for related entities
+
+## Code Review Checklist
+
+When reviewing command handler changes, verify:
+
+- [ ] **UpdatedAt = DateTime.UtcNow** is present in update handlers
+- [ ] Error handling follows established patterns
+- [ ] Async patterns are used correctly
+- [ ] Repository interfaces are used (not concrete implementations)
+- [ ] Related entities are updated if needed
+
+## Historical Issues
+
+This checklist prevents regressions of these resolved issues:
+
+- **BI-2025-09-20-001**: Missing UpdatedAt in role updates caused conditional request test failures
+- **BI-2025-09-20-002**: Inconsistent UpdatedAt handling across entities
+
+## Testing
+
+After implementing a command handler:
+
+1. Run relevant integration tests
+2. Verify conditional request behavior if entity has API endpoints
+3. Test Last-Modified headers are updated correctly
+4. Ensure optimistic concurrency works if implemented
+
+---
+
+*Last Updated: 2025-09-20*  
+*Related: [Conditional Request Tests](../specs/2025-09-10-api-response-caching/)*

--- a/src/App/Features/People/CommandHandlers.cs
+++ b/src/App/Features/People/CommandHandlers.cs
@@ -65,6 +65,7 @@ public class UpdatePersonCommandHandler(IPersonRepository personRepository, IRol
             }
         }
 
+        person.UpdatedAt = DateTime.UtcNow;
         await personRepository.UpdateAsync(person, cancellationToken);
     }
 }

--- a/src/App/Features/Roles/CommandHandlers.cs
+++ b/src/App/Features/Roles/CommandHandlers.cs
@@ -25,6 +25,7 @@ public class UpdateRoleCommandHandler(IRoleRepository roleRepository) : IRequest
             ?? throw new KeyNotFoundException($"Role {request.Id} not found");
         role.Name = request.Name;
         role.Description = request.Description;
+        role.UpdatedAt = DateTime.UtcNow;
         await roleRepository.UpdateAsync(role, cancellationToken);
     }
 }

--- a/test/Tests.Integration.Backend/OutputCaching/ConditionalRequestTests.cs
+++ b/test/Tests.Integration.Backend/OutputCaching/ConditionalRequestTests.cs
@@ -159,6 +159,9 @@ public class ConditionalRequestTests : IntegrationTestBase
                 return;
             }
 
+            // Wait 1 second to ensure update happens in a different second for HTTP date precision
+            await Task.Delay(1100);
+
             // Update the data via API (not direct database modification) - need admin client for PUT
             var adminClient = await CreateAdminClientAsync();
             var updateRequest = new { name = role.Name, description = "Updated Description" };


### PR DESCRIPTION
Resolves CI backend integration test failures by eliminating dependency on build artifacts that were causing race conditions. Tests now build and run independently for consistent CI execution.

Key changes:
- Remove build job dependency to avoid artifact chain issues
- Add self-contained restore and build steps for tests
- Re-enable backend integration tests in PR validation summary
- Increase timeout from 10 to 15 minutes for stability
- Include backend integration tests in dev and main branch validation

This restores proper quality gates while ensuring reliable CI execution.

🤖 Generated with [Claude Code](https://claude.ai/code)