### PR TITLE
fix: remove artifact dependencies from staging and PR workflows

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,19 +10,18 @@ env:
   NODE_VERSION: '20.x'
 
 jobs:
-  # Skip deployment if it's a Copilot commit or if no PR artifacts are available
+  # Skip deployment if it's a Copilot commit
   check-commit:
     name: Check Deployment Prerequisites
     runs-on: ubuntu-latest
     outputs:
       should-deploy: ${{ steps.check.outputs.should-deploy }}
-      artifact-exists: ${{ steps.artifact-check.outputs.artifact-exists }}
-    
+
     steps:
     - name: Check if Copilot commit
       id: check
       run: |
-        if [[ "${{ github.event.head_commit.author.email }}" == *"copilot"* ]] || 
+        if [[ "${{ github.event.head_commit.author.email }}" == *"copilot"* ]] ||
            [[ "${{ github.event.head_commit.author.name }}" == *"copilot"* ]]; then
           echo "should-deploy=false" >> $GITHUB_OUTPUT
           echo "⏭️ Skipping deployment - Copilot commit detected"
@@ -30,98 +29,44 @@ jobs:
           echo "should-deploy=true" >> $GITHUB_OUTPUT
           echo "✅ Proceeding with staging deployment"
         fi
-        
-    - name: Check for PR artifacts
-      id: artifact-check
-      run: |
-        # This will be verified when we try to download the artifact
-        echo "artifact-exists=true" >> $GITHUB_OUTPUT
-        echo "📦 Will attempt to download pr-build-${{ github.sha }} or feature-build-${{ github.sha }}"
 
   staging-smoke-tests:
-    name: Staging Smoke Tests (Reuse PR Artifacts)
+    name: Staging Smoke Tests (Independent Build)
     runs-on: ubuntu-latest
     needs: check-commit
     if: needs.check-commit.outputs.should-deploy == 'true'
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
-    - name: Download PR build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: pr-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Download feature build artifacts (fallback)
-      uses: actions/download-artifact@v4
-      with:
-        name: feature-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Verify artifacts and version
-      run: |
-        echo "📦 Verifying staging deployment artifacts..."
-        if [ -f "version.json" ]; then
-          echo "📋 Deploying version:"
-          cat version.json | jq .
-          VERSION=$(cat version.json | jq -r '.version')
-          if [ "$VERSION" != "${{ github.sha }}" ]; then
-            echo "❌ Version mismatch! Expected: ${{ github.sha }}, Found: $VERSION"
-            exit 1
-          fi
-          echo "✅ Version verified for staging deployment"
-        else
-          echo "❌ No version.json found in artifact - cannot proceed"
-          exit 1
-        fi
-        
-        echo "📁 Verifying build outputs:"
-        ls -la src/Api/bin/Release/net8.0/ || echo "⚠️ API build directory not found"
-        
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-        
+        cache: true
+        cache-dependency-path: 'src/**/*.csproj'
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
         cache-dependency-path: 'src/Angular/package-lock.json'
-        
-    # Install Angular dependencies so the dev server can start
+
+    - name: Build backend for staging
+      run: |
+        echo "🏗️ Building backend for staging deployment..."
+        dotnet restore solutions/Crud.sln
+        dotnet build solutions/Crud.sln --no-restore --configuration Release
+        echo "✅ Backend build completed"
+
     - name: Install Angular dependencies
       working-directory: ./src/Angular
       run: |
         echo "📦 Installing Angular dependencies for smoke tests..."
         npm ci
         echo "✅ Angular dependencies installed"
-        
-    # Verify Angular can compile and run
-    - name: Verify Angular setup
-      working-directory: ./src/Angular
-      run: |
-        echo "🔍 Verifying Angular can compile..."
-        npm run ng -- version
-        echo "✅ Angular CLI verified"
-        
-    # Appsettings should already be in artifacts from PR build
-    - name: Verify appsettings in artifacts
-      run: |
-        echo "📁 Verifying appsettings files in artifacts..."
-        if [ -f "src/Api/appsettings.json" ]; then
-          echo "✅ Appsettings files found in artifacts"
-          ls -la src/Api/appsettings*.json
-        elif [ -f "src/Api/bin/Release/net8.0/appsettings.json" ]; then
-          echo "✅ Appsettings files found in build output"
-          ls -la src/Api/bin/Release/net8.0/appsettings*.json
-        else
-          echo "⚠️ No appsettings files found - copying from checkout"
-          cp src/Api/appsettings*.json src/Api/bin/Release/net8.0/
-        fi
         
     # Install E2E dependencies
     - name: Install E2E dependencies
@@ -155,35 +100,36 @@ jobs:
         retention-days: 7
 
   prepare-staging-artifacts:
-    name: Prepare Staging Deployment Artifacts (Reuse PR Artifacts)
+    name: Prepare Staging Deployment Artifacts (Independent Build)
     runs-on: ubuntu-latest
     needs: staging-smoke-tests
     if: needs.staging-smoke-tests.result == 'success'
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
-    - name: Download PR build artifacts
-      uses: actions/download-artifact@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        name: pr-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Download feature build artifacts (fallback)
-      uses: actions/download-artifact@v4
-      with:
-        name: feature-build-${{ github.sha }}
-      continue-on-error: true
-      
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+        cache: true
+        cache-dependency-path: 'src/**/*.csproj'
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
         cache-dependency-path: 'src/Angular/package-lock.json'
-        
-    # Build Angular for staging config
+
+    - name: Build backend for staging
+      run: |
+        echo "🏗️ Building backend for staging deployment..."
+        dotnet restore solutions/Crud.sln
+        dotnet build solutions/Crud.sln --no-restore --configuration Release
+        echo "✅ Backend build completed"
+
     - name: Build frontend for staging
       working-directory: ./src/Angular
       run: |
@@ -191,39 +137,30 @@ jobs:
         npm ci
         npm run build -- --configuration=staging
         echo "✅ Frontend built for staging configuration"
-        
-    # Package backend binaries (reusing PR artifacts)
+
     - name: Package backend for staging
       run: |
-        echo "📦 Packaging backend using PR-validated artifacts (NO REBUILD)..."
-        # Verify the pre-built binaries exist
-        if [ ! -d "src/Api/bin/Release/net8.0" ]; then
-          echo "❌ ERROR: Pre-built backend artifacts not found!"
-          echo "Expected: src/Api/bin/Release/net8.0/"
-          echo "Available:"
-          find . -name "*.dll" -path "*/Release/*" | head -10
-          exit 1
-        fi
-        
-        # Package the already-built backend
+        echo "📦 Packaging backend for staging deployment..."
+
+        # Package the built backend
         mkdir -p ./staging-backend
         cp -r src/Api/bin/Release/net8.0/* ./staging-backend/
-        
-        # Appsettings should already be in artifacts
+
+        # Copy appsettings files
         if [ -f "src/Api/appsettings.json" ]; then
           cp src/Api/appsettings*.json ./staging-backend/
           echo "✅ Appsettings files copied to staging package"
         fi
-        
-        # Update version info for staging environment
+
+        # Create version info for staging environment
         echo "{\"version\":\"${{ github.sha }}\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"${{ github.ref_name }}\",\"buildNumber\":\"${{ github.run_number }}\",\"environment\":\"staging\"}" > ./staging-backend/version.json
-        echo "📋 Version info updated for staging:"
+        echo "📋 Version info for staging:"
         cat ./staging-backend/version.json
-        
+
         cd ./staging-backend
         zip -r ../staging-api.zip .
         cd ..
-        echo "✅ Backend packaged using PR artifacts WITHOUT rebuilding"
+        echo "✅ Backend packaged for staging deployment"
         
     - name: Package frontend
       run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -23,77 +23,26 @@ env:
   NODE_VERSION: '20.x'
 
 jobs:
-  # Simplified: Always build if needed. Try to download artifacts first, build if not available.
   build:
     name: Build Solution
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
-    # Try to download feature artifacts first (optimization)
-    - name: Download feature build artifacts (if available)
-      id: download-artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: feature-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Check if build needed
-      id: build-needed
-      run: |
-        if [ "${{ steps.download-artifacts.outcome }}" == "success" ] && [ -f "version.json" ]; then
-          echo "needed=false" >> $GITHUB_OUTPUT
-          echo "✅ Feature build artifacts found - reusing"
-          cat version.json | jq .
-        else
-          echo "needed=true" >> $GITHUB_OUTPUT
-          echo "🔨 No artifacts found - will build"
-        fi
-      
+
     - name: Setup .NET
-      if: steps.build-needed.outputs.needed == 'true'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         cache: true
         cache-dependency-path: 'src/**/*.csproj'
-        
+
     - name: Restore .NET dependencies
-      if: steps.build-needed.outputs.needed == 'true'
       run: dotnet restore solutions/Crud.sln
-      
+
     - name: Build solution
-      if: steps.build-needed.outputs.needed == 'true'
       run: dotnet build solutions/Crud.sln --no-restore --configuration Release
-      
-    - name: Create versioned artifact (if built)
-      if: steps.build-needed.outputs.needed == 'true'
-      run: |
-        echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
-        echo "BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-        # Package with version info
-        echo "{\"version\":\"${{ github.sha }}\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"${{ github.ref_name }}\",\"buildNumber\":\"${{ github.run_number }}\",\"workflow\":\"pr-validation\"}" > version.json
-        
-    - name: Verify appsettings files exist (if built)
-      if: steps.build-needed.outputs.needed == 'true'
-      run: |
-        echo "📁 Verifying appsettings files before artifact upload:"
-        ls -la src/Api/appsettings*.json
-        echo "✅ All appsettings files found"
-      
-    - name: Upload build artifacts (if built)
-      if: steps.build-needed.outputs.needed == 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: pr-build-${{ github.sha }}
-        path: |
-          src/*/bin/Release/
-          test/*/bin/Release/
-          src/Api/appsettings*.json
-          version.json
-        retention-days: 7
 
   code-quality:
     name: Code Quality & Auto-Format
@@ -204,50 +153,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, code-quality]
     if: always() && needs.build.result == 'success'
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         cache: true
         cache-dependency-path: 'src/**/*.csproj'
-        
-    - name: Download build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: feature-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Download PR build artifacts (fallback)
-      uses: actions/download-artifact@v4
-      with:
-        name: pr-build-${{ github.sha }}
-      continue-on-error: true
-    
-    - name: Copy appsettings to test output
-      run: |
-        echo "📁 Listing artifact structure:"
-        ls -la src/Api/ || echo "src/Api/ not found"
-        ls -la src/Api/bin/Release/net8.0/ || echo "bin directory not found"
-        
-        # Copy appsettings files if they exist
-        if [ -f "src/Api/appsettings.json" ]; then
-          cp src/Api/appsettings*.json src/Api/bin/Release/net8.0/
-          echo "✅ Appsettings files copied from src/Api/"
-        elif [ -f "appsettings.json" ]; then
-          cp appsettings*.json src/Api/bin/Release/net8.0/
-          echo "✅ Appsettings files copied from root"
-        else
-          echo "⚠️ No appsettings files found to copy"
-        fi
-        
-        echo "📁 Final output directory contents:"
-        ls -la src/Api/bin/Release/net8.0/*.json || echo "No JSON files in output"
-        
+
     - name: Run Backend Unit Tests
       run: dotnet test test/Tests.Unit.Backend/Tests.Unit.Backend.csproj --configuration Release --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=normal"
       
@@ -317,50 +234,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, code-quality]
     if: false  # Temporarily disabled pending CI artifact resolution
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         cache: true
         cache-dependency-path: 'src/**/*.csproj'
-        
-    - name: Download build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: feature-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Download PR build artifacts (fallback)
-      uses: actions/download-artifact@v4
-      with:
-        name: pr-build-${{ github.sha }}
-      continue-on-error: true
-    
-    - name: Copy appsettings to test output
-      run: |
-        echo "📁 Listing artifact structure:"
-        ls -la src/Api/ || echo "src/Api/ not found"
-        ls -la src/Api/bin/Release/net8.0/ || echo "bin directory not found"
-        
-        # Copy appsettings files if they exist
-        if [ -f "src/Api/appsettings.json" ]; then
-          cp src/Api/appsettings*.json src/Api/bin/Release/net8.0/
-          echo "✅ Appsettings files copied from src/Api/"
-        elif [ -f "appsettings.json" ]; then
-          cp appsettings*.json src/Api/bin/Release/net8.0/
-          echo "✅ Appsettings files copied from root"
-        else
-          echo "⚠️ No appsettings files found to copy"
-        fi
-        
-        echo "📁 Final output directory contents:"
-        ls -la src/Api/bin/Release/net8.0/*.json || echo "No JSON files in output"
-        
+
     - name: Run Backend Integration Tests with SQLite
       run: dotnet test test/Tests.Integration.Backend/Tests.Integration.Backend.csproj --configuration Release --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=detailed"
       continue-on-error: true
@@ -390,39 +275,34 @@ jobs:
     needs: [build, backend-unit-tests, frontend-unit-tests, backend-integration-tests]
     # Only run E2E tests for PRs to main (production). PRs to dev get E2E coverage in staging deployment.
     if: github.event.pull_request.base.ref == 'main' && needs.build.result == 'success'
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-        
+        cache: true
+        cache-dependency-path: 'src/**/*.csproj'
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
         cache-dependency-path: 'src/Angular/package-lock.json'
-        
-    - name: Download build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: feature-build-${{ github.sha }}
-      continue-on-error: true
-        
-    - name: Download PR build artifacts (fallback)
-      uses: actions/download-artifact@v4
-      with:
-        name: pr-build-${{ github.sha }}
-      continue-on-error: true
-      
+
+    - name: Build backend for E2E tests
+      run: |
+        dotnet restore solutions/Crud.sln
+        dotnet build solutions/Crud.sln --no-restore --configuration Release
+
     - name: Install Angular dependencies
       working-directory: ./src/Angular
       run: npm ci
-      
+
     - name: Build Angular for production
       working-directory: ./src/Angular
       run: npm run build


### PR DESCRIPTION
Remove all artifact download dependencies that were causing staging smoke test failures. Each workflow now builds independently:

- Staging workflow: builds backend and frontend independently for deployment
- PR validation: builds solution independently without relying on feature artifacts
- Simplified check-commit job to only check for Copilot commits

This eliminates the "Artifact not found" errors that were blocking smoke test execution.

🤖 Generated with [Claude Code](https://claude.ai/code)