### PR TITLE
fix: resolve playwright webServer startup failures in CI

### DIFF
--- a/test/Tests.E2E.NG/playwright.config.ts
+++ b/test/Tests.E2E.NG/playwright.config.ts
@@ -40,13 +40,15 @@ export default defineConfig({
   webServer: [
     {
       // API Server configuration
-      command: 'dotnet run --project ../../src/Api/Api.csproj --launch-profile testing',
-      cwd: process.cwd(),
+      command: process.env.CI
+        ? `cd ${path.join(process.cwd(), '..', '..')} && dotnet run --project src/Api/Api.csproj --launch-profile testing`
+        : 'dotnet run --project ../../src/Api/Api.csproj --launch-profile testing',
+      cwd: process.env.CI ? undefined : process.cwd(),
       url: 'http://localhost:5172/health',
       timeout: 60 * 1000, // 60 seconds to start
       reuseExistingServer: !process.env.CI, // Reuse locally, fresh in CI
-      stdout: 'ignore',
-      stderr: 'ignore',
+      stdout: process.env.CI ? 'pipe' : 'ignore', // Show output in CI for debugging
+      stderr: process.env.CI ? 'pipe' : 'ignore', // Show errors in CI for debugging
       env: {
         // EXPLICITLY Testing configuration only - never multi-config
         ASPNETCORE_ENVIRONMENT: 'Testing',
@@ -81,8 +83,10 @@ export default defineConfig({
     },
     {
       // Angular Server configuration
-      command: process.env.CI ? 'npm run start:ci' : 'npm start',
-      cwd: path.join(process.cwd(), '..', '..', 'src', 'Angular'),
+      command: process.env.CI
+        ? `cd ${path.join(process.cwd(), '..', '..', 'src', 'Angular')} && npm run start:ci`
+        : 'npm start',
+      cwd: process.env.CI ? undefined : path.join(process.cwd(), '..', '..', 'src', 'Angular'),
       url: 'http://localhost:4200',
       timeout: 120 * 1000, // 2 minutes for Angular compilation
       reuseExistingServer: !process.env.CI,
@@ -91,6 +95,7 @@ export default defineConfig({
       env: {
         PORT: '4200',
         API_URL: 'http://localhost:5172',
+        PATH: process.env.PATH, // Ensure PATH is inherited for CI
       },
     }
   ],


### PR DESCRIPTION
## Summary
- Fixes "Exit code: 127" webServer startup failures in staging deployment
- Resolves both API and Angular webServer configuration issues in CI environment

## Changes Made
- **API webServer**: Use absolute paths with shell commands in CI
- **Angular webServer**: Fix directory and PATH inheritance issues  
- **Debugging**: Enable stdout/stderr output in CI for better error visibility
- **Environment**: Inherit PATH variable for npm/node command availability

## Root Cause
Playwright's webServer configuration was failing in CI because:
1. Relative paths didn't work from E2E test directory context
2. npm/node commands weren't available in webServer subprocess PATH
3. Limited debugging output made troubleshooting difficult

## Expected Result
- ✅ webServer startup should succeed in CI 
- ✅ Original smoke test fixes should now be testable
- ✅ Should reduce staging deployment failures from 2 → 0

## Test Plan
- [x] Local testing confirms webServer still works
- [ ] Staging deployment should now complete successfully
- [ ] Smoke tests should validate our original fixes worked

🤖 Generated with [Claude Code](https://claude.ai/code)