### PR TITLE
fix: add statuses:write permission to PR-to-Dev workflow

### DIFF
--- a/.github/workflows/pr-to-dev.yml
+++ b/.github/workflows/pr-to-dev.yml
@@ -34,6 +34,7 @@ permissions:
   checks: write
   actions: read         # For downloading artifacts from feature workflow
   repository-projects: read  # Additional permission that might be needed
+  statuses: write       # For creating commit statuses in PR summary
 
 env:
   DOTNET_VERSION: '8.0.x'


### PR DESCRIPTION
Fixes GitHub Actions failure where PR summary job couldn't create commit statuses. The job was getting HTTP 403 "Resource not accessible by integration" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)