### PR TITLE
fix: improve Windows detection in kill-servers script and add CI mode…

### DIFF
--- a/scripts/kill-servers.ps1
+++ b/scripts/kill-servers.ps1
@@ -15,7 +15,10 @@ $killedProcesses = 0
 function Get-ProcessByPort {
     param([int]$Port)
 
-    if ($IsWindows) {
+    # Better Windows detection - check for Windows OS
+    $isWindowsOS = ($env:OS -eq 'Windows_NT') -or ($PSVersionTable.PSVersion.Major -le 5) -or ($PSVersionTable.Platform -eq 'Win32NT')
+
+    if ($isWindowsOS) {
         # Windows: Use Get-NetTCPConnection
         $connections = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
         if ($connections) {

--- a/test/Tests.E2E.NG/package.json
+++ b/test/Tests.E2E.NG/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "playwright test",
     "test:webserver": "npx cross-env API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 BYPASS_AUTHORIZATION_FOR_E2E=true E2E_TEST_MODE=true playwright test",
-    "test:smoke": "npx cross-env TEST_CATEGORY=smoke API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 BYPASS_AUTHORIZATION_FOR_E2E=true E2E_TEST_MODE=true playwright test",
+    "test:smoke": "npx cross-env CI=true TEST_CATEGORY=smoke API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 BYPASS_AUTHORIZATION_FOR_E2E=true E2E_TEST_MODE=true playwright test",
     "test:critical": "npx cross-env TEST_CATEGORY=critical API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 BYPASS_AUTHORIZATION_FOR_E2E=true E2E_TEST_MODE=true playwright test",
     "test:extended": "npx cross-env TEST_CATEGORY=extended API_PORT=5172 ANGULAR_PORT=4200 DATABASE_PATH=test.db API_URL=http://localhost:5172 ANGULAR_URL=http://localhost:4200 BYPASS_AUTHORIZATION_FOR_E2E=true E2E_TEST_MODE=true playwright test",
     "test:headed": "playwright test --headed",


### PR DESCRIPTION
… to smoke tests

- Fix kill-servers.ps1 to properly detect Windows in MINGW64/Git Bash environments
- Add CI=true environment variable to test:smoke command for proper CI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)